### PR TITLE
Upgrade to 3.15.0 provider version

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,9 @@ The script will process each task in the TASKS array and drop a metric into New 
 - **talisker.id** - the id of the task
 - **talisker.name** - the name of the task
 - **talisker.monitorName** - the name of the monitor (as set by you)
-- **talisker.monitorId** - the ID of the monitor (as set by you)
 
 You could for example target the output of a task with the following NRQL: 
-`from Metric select latest(talisker.value) where talisker.monitorId='your-monitor-id' and talisker.id='your-task-id`
+`from Metric select latest(talisker.value) where talisker.monitorName='your-monitor-name' and talisker.id='your-task-id`
 
 ### Event Support
 Talisker also supports storing the output results as events rather than metrics. This can be chosen on a task level by setting `ingestType` to `event`. Events will appear in the event type `taliskerSample`. e.g.: `select latest(value) from taliskerSample facet talisker.name`

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,8 @@
 module "example1" {
   source = "./modules/Talisker"
   monitorName = "Talisker NRDB Alerts"
-  frequency = 15
+  period = "EVERY_15_MINUTES" # period as specified by resouce
+  frequency = 15  # minutes as a number
   userAPIKey = var.userAPIKey
   insertAPIKey = var.insertAPIKey
   accountId = var.terraformNRAccountId

--- a/modules/Talisker/alerts.tf
+++ b/modules/Talisker/alerts.tf
@@ -26,7 +26,7 @@ resource "newrelic_nrql_alert_condition" "condition" {
   aggregation_timer = 60
 
   nrql {
-    query             = var.tasks[count.index].ingestType == "event" ? "from ${var.nameSpace}Sample select latest(value) where talisker.monitorId ='${newrelic_synthetics_monitor.monitor.id}' and talisker.id='${var.tasks[count.index].id}'" : "from Metric select latest(${var.nameSpace}.value) where talisker.monitorId ='${newrelic_synthetics_monitor.monitor.id}' and talisker.id='${var.tasks[count.index].id}'"
+    query             = var.tasks[count.index].ingestType == "event" ? "from ${var.nameSpace}Sample select latest(value) where talisker.monitorName ='${newrelic_synthetics_script_monitor.monitor.id}' and talisker.id='${var.tasks[count.index].id}'" : "from Metric select latest(${var.nameSpace}.value) where talisker.monitorName ='${newrelic_synthetics_script_monitor.monitor.name}' and talisker.id='${var.tasks[count.index].id}'"
   }
 
     critical {

--- a/modules/Talisker/dashboard.tf
+++ b/modules/Talisker/dashboard.tf
@@ -14,7 +14,7 @@ resource "newrelic_one_dashboard" "dashboard" {
       warning=  0.9
       
       nrql_query {
-        query       = "SELECT latest(custom.tasksSucceeded) as 'Tasks succeeded' from SyntheticCheck  since 2 hours ago where monitorId='${newrelic_synthetics_monitor.monitor.id}'"
+        query       = "SELECT latest(custom.tasksSucceeded) as 'Tasks succeeded' from SyntheticCheck  since 2 hours ago where monitorName='${newrelic_synthetics_script_monitor.monitor.name}'"
       }
     }
     widget_billboard {
@@ -27,7 +27,7 @@ resource "newrelic_one_dashboard" "dashboard" {
       warning =  0.1
       
       nrql_query {
-        query       = "SELECT latest(custom.tasksFailed) as 'Tasks failed' from SyntheticCheck  since 2 hours ago where monitorId='${newrelic_synthetics_monitor.monitor.id}'"
+        query       = "SELECT latest(custom.tasksFailed) as 'Tasks failed' from SyntheticCheck  since 2 hours ago where monitorName='${newrelic_synthetics_script_monitor.monitor.name}'"
       }
     }
 
@@ -39,7 +39,7 @@ resource "newrelic_one_dashboard" "dashboard" {
       width = 3
 
       nrql_query {
-        query       = "SELECT latest(result) from SyntheticCheck where monitorId='${newrelic_synthetics_monitor.monitor.id}'"
+        query       = "SELECT latest(result) from SyntheticCheck where monitorName='${newrelic_synthetics_script_monitor.monitor.name}'"
       }
     }
 
@@ -50,7 +50,7 @@ resource "newrelic_one_dashboard" "dashboard" {
       column = 8
       width=  5
       nrql_query {
-        query       = "SELECT latest(custom.tasksSuccessRate) as 'Successful runs' from SyntheticCheck timeseries  since 2 hours ago where monitorId='${newrelic_synthetics_monitor.monitor.id}'"
+        query       = "SELECT latest(custom.tasksSuccessRate) as 'Successful runs' from SyntheticCheck timeseries  since 2 hours ago where monitorName='${newrelic_synthetics_script_monitor.monitor.name}'"
       }
     }
 
@@ -63,7 +63,7 @@ resource "newrelic_one_dashboard" "dashboard" {
       column = 1
       width = 6
       nrql_query {
-        query       = "from Metric select latest(${var.nameSpace}.value) where talisker.monitorId ='${newrelic_synthetics_monitor.monitor.id}' facet talisker.name "
+        query       = "from Metric select latest(${var.nameSpace}.value) where talisker.monitorName ='${newrelic_synthetics_script_monitor.monitor.name}' facet talisker.name "
       }
     }
 
@@ -74,7 +74,7 @@ resource "newrelic_one_dashboard" "dashboard" {
       width = 6
       height = 4
       nrql_query {
-        query       = "SELECT custom.failureDetail as 'Failure detail' from SyntheticCheck  since 2 hours ago where result='FAILED' and monitorId='${newrelic_synthetics_monitor.monitor.id}'"
+        query       = "SELECT custom.failureDetail as 'Failure detail' from SyntheticCheck  since 2 hours ago where result='FAILED' and monitorName='${newrelic_synthetics_script_monitor.monitor.name}'"
       }
     }
 
@@ -86,7 +86,7 @@ resource "newrelic_one_dashboard" "dashboard" {
       column = 1
       width = 6
       nrql_query {
-        query       = "from ${var.nameSpace}Sample select latest(value) where talisker.monitorId ='${newrelic_synthetics_monitor.monitor.id}' facet talisker.name "
+        query       = "from ${var.nameSpace}Sample select latest(value) where talisker.monitorName ='${newrelic_synthetics_script_monitor.monitor.name}' facet talisker.name "
       }
     }
     widget_table  {

--- a/modules/Talisker/main.tf
+++ b/modules/Talisker/main.tf
@@ -1,7 +1,8 @@
 variable "monitorName" {}
-variable "nameSpace" { default = "talisker"}
+variable "nameSpace" { default = "talisker"} #each deployment of terraform this needs to be unique value
 variable "userAPIKey" {}
 variable "insertAPIKey" {}
+variable "period" {}
 variable "frequency" {}
 variable "dataCenter" { default = "US" }
 variable "accountId" {}
@@ -34,32 +35,40 @@ variable "notificationChannelId" {}
 
 # Setup the secure credentials for querying and sendign data
 resource "newrelic_synthetics_secure_credential" "query" {
-  key = "TALISKER_QUERY_KEY_${replace(newrelic_synthetics_monitor.monitor.id,"-","_")}"
+  key = "TALISKER_QUERY_KEY_${var.nameSpace}"
   value = var.userAPIKey
   description = "API key for querying New Relic data"
 }
 
 resource "newrelic_synthetics_secure_credential" "insert" {
-  key = "TALISKER_INSERT_KEY_${replace(newrelic_synthetics_monitor.monitor.id,"-","_")}"
+  key = "TALISKER_INSERT_KEY_${var.nameSpace}"
   value = var.insertAPIKey
   description = "API key for inserting metrics data to New Relic"
 }
 
 
-resource "newrelic_synthetics_monitor" "monitor" {
+resource "newrelic_synthetics_script_monitor" "monitor" {
   name = var.monitorName
   type = "SCRIPT_API"
-  frequency = var.frequency
+  period = var.period
   status = "ENABLED"
-  locations = ["AWS_US_EAST_1"]
+  locations_public = ["AWS_US_EAST_1"]
+  script = "${local.header_js} ${data.local_file.base_js.content}"
+  script_language      = "JAVASCRIPT"
+  runtime_type         = "NODE_API"
+  runtime_type_version = "16.10"
+
+
+  # depends_on = [newrelic_synthetics_secure_credential.query,newrelic_synthetics_secure_credential.insert]
 }
 
 
 data "local_file" "base_js" {
     filename = "${path.module}/src/base_script.js"
 }
-data "template_file" "header_js" {
-    template = templatefile(
+
+locals {
+      header_js = templatefile(
                "${path.module}/src/script_header.tmpl",
                {
                  tasks = <<TASKBLOCK
@@ -78,23 +87,45 @@ data "template_file" "header_js" {
 %{ endfor ~}]
 TASKBLOCK
                 monitorName = var.monitorName
-                monitorId = newrelic_synthetics_monitor.monitor.id
                 nameSpace = var.nameSpace
-                insertKeyName = "TALISKER_INSERT_KEY_${upper(replace(newrelic_synthetics_monitor.monitor.id,"-","_"))}"
-                queryKeyName = "TALISKER_QUERY_KEY_${upper(replace(newrelic_synthetics_monitor.monitor.id,"-","_"))}"
-                keySuffix = replace(newrelic_synthetics_monitor.monitor.id,"-","_")
+                insertKeyName = "TALISKER_INSERT_KEY_${upper(var.nameSpace)}"
+                queryKeyName = "TALISKER_QUERY_KEY_${upper(var.nameSpace)}"
                 dataCenter = var.dataCenter
                 accountId = var.accountId
                }
         )
 }
 
-resource "newrelic_synthetics_monitor_script" "main" {
-  monitor_id = newrelic_synthetics_monitor.monitor.id
-  text = "${data.template_file.header_js.rendered} ${data.local_file.base_js.content}"
-
-  depends_on = [newrelic_synthetics_secure_credential.query,newrelic_synthetics_secure_credential.insert]
-}
+# data "template_file" "header_js" {
+#     template = templatefile(
+#                "${path.module}/src/script_header.tmpl",
+#                {
+#                  tasks = <<TASKBLOCK
+# [%{ for task in var.tasks ~}
+# {
+#     "id":${jsonencode(task.id)},
+#     "name":${jsonencode(task.name)},
+#     "accountId":${jsonencode(task.accountId)},
+#     "selector":${jsonencode(task.selector)},
+#     "chaining":${jsonencode(task.chaining)},
+#     "nullValue":${jsonencode(task.fillNullValue)},
+#     "invertResult":${jsonencode(task.invertResult)},
+#     "ingestType":${jsonencode(task.ingestType)},
+#     "query":${jsonencode(task.query)}
+# },
+# %{ endfor ~}]
+# TASKBLOCK
+#                 monitorName = var.monitorName
+#                 monitorId = newrelic_synthetics_script_monitor.monitor.id
+#                 nameSpace = var.nameSpace
+#                 insertKeyName = "TALISKER_INSERT_KEY_${upper(replace(newrelic_synthetics_script_monitor.monitor.id,"-","_"))}"
+#                 queryKeyName = "TALISKER_QUERY_KEY_${upper(replace(newrelic_synthetics_script_monitor.monitor.id,"-","_"))}"
+#                 keySuffix = replace(newrelic_synthetics_script_monitor.monitor.id,"-","_")
+#                 dataCenter = var.dataCenter
+#                 accountId = var.accountId
+#                }
+#         )
+# }
 
 
 

--- a/modules/Talisker/provider.tf
+++ b/modules/Talisker/provider.tf
@@ -2,7 +2,7 @@ terraform {
 required_providers {
     newrelic = {
       source  = "newrelic/newrelic"
-      version = "~> 2.45.1"
+      version = "~> 3.15.0"
     }
   }
 }

--- a/modules/Talisker/src/base_script.js
+++ b/modules/Talisker/src/base_script.js
@@ -467,7 +467,6 @@ async function runtasks(tasks) {
     if(metricsInnerPayload && metricsInnerPayload.length > 0) {
         let commonMetricBlock={"attributes": {}}
         commonMetricBlock.attributes[`${NAMESPACE}.monitorName`]=MONITOR_NAME
-        commonMetricBlock.attributes[`${NAMESPACE}.monitorId`]=MONITOR_ID
         commonMetricBlock.attributes[`talisker.version`]=TALISKER_VERSION
     
         let metricsPayLoad=[{ 
@@ -490,7 +489,6 @@ async function runtasks(tasks) {
         //add talisker runtime meta data
         eventsInnerPayload.forEach((event)=>{
             event[`${NAMESPACE}.monitorName`]=MONITOR_NAME
-            event[`${NAMESPACE}.monitorId`]=MONITOR_ID
             event[`talisker.version`]=TALISKER_VERSION
         })
     

--- a/modules/Talisker/src/script_header.tmpl
+++ b/modules/Talisker/src/script_header.tmpl
@@ -1,6 +1,5 @@
 const TASKS = ${tasks}
 const MONITOR_NAME="${monitorName}"
-const MONITOR_ID="${monitorId}"
 const NAMESPACE ="${nameSpace}"         // metric details re prefixed with this
 const NEWRELIC_DC = "${dataCenter}"     // datacenter for account - US or EU
 const ACCOUNT_ID = "${accountId}"        // Account ID (required if ingesting events)

--- a/modules/Talisker/watcher.tf
+++ b/modules/Talisker/watcher.tf
@@ -28,7 +28,7 @@ resource "newrelic_nrql_alert_condition" "watcher" {
   aggregation_timer = 60
 
   nrql {
-    query             = "select latest(custom.tasksSuccessRate) from SyntheticCheck where  monitorId = '${newrelic_synthetics_monitor.monitor.id}'"
+    query             = "select latest(custom.tasksSuccessRate) from SyntheticCheck where  monitorId = '${newrelic_synthetics_script_monitor.monitor.id}'"
   }
 
   critical {

--- a/provider.tf
+++ b/provider.tf
@@ -1,11 +1,11 @@
 # Configure the terraform and New Relic provider versions
 # More details: https://www.terraform.io/docs/configuration/provider-requirements.html
 terraform {
-  required_version = "~> 1.2.0"
+  required_version = "> 1.2.0"
   required_providers {
     newrelic = {
       source  = "newrelic/newrelic"
-      version = "~> 2.45.1"
+      version = "~> 3.15.0"
     }
   }
 }


### PR DESCRIPTION
Refactors script monitor resource to use latest resource 'newrelic_synthetics_script_monitor'. Unfortunately this new resource combines the script with the monitor which means the ID of the monitor is unavilable and was causing a cyclical dependency. Ive removed the monitorId throughout and replaced with nameSpace. This means if you deploy Talisker more than once to a single account the namesSpace value must be set uniquely for each deployment instance.